### PR TITLE
Add page_scans property for poems.

### DIFF
--- a/_data/poems/xli-poems/chansons-innocentes-i.yaml
+++ b/_data/poems/xli-poems/chansons-innocentes-i.yaml
@@ -1,5 +1,8 @@
 title: Chansons Innocentes I
 
+page_scans:
+    - 'https://babel.hathitrust.org/cgi/pt?id=uc1.$b408727&view=1up&seq=27'
+
 first_line: why did you go
 
 text: |-1

--- a/_data/poems/xli-poems/chansons-innocentes-ii.yaml
+++ b/_data/poems/xli-poems/chansons-innocentes-ii.yaml
@@ -1,5 +1,8 @@
 title: Chansons Innocentes II
 
+page_scans:
+    - 'https://babel.hathitrust.org/cgi/pt?id=uc1.$b408727&view=1up&seq=28'
+
 first_line: little tree
 
 text: |-1

--- a/_data/poems/xli-poems/la-guerre-i.yaml
+++ b/_data/poems/xli-poems/la-guerre-i.yaml
@@ -1,5 +1,8 @@
 title: La Guerre I
 
+page_scans:
+    - 'https://babel.hathitrust.org/cgi/pt?id=uc1.$b408727&view=1up&seq=43'
+
 first_line: earth like a tipsy
 
 text: |-1

--- a/_data/poems/xli-poems/la-guerre-ii.yaml
+++ b/_data/poems/xli-poems/la-guerre-ii.yaml
@@ -1,5 +1,8 @@
 title: La Guerre II
 
+page_scans:
+    - 'https://babel.hathitrust.org/cgi/pt?id=uc1.$b408727&view=1up&seq=44'
+
 first_line: Humanity i love you
 
 text: |-1

--- a/_data/poems/xli-poems/portraits-i.yaml
+++ b/_data/poems/xli-poems/portraits-i.yaml
@@ -1,5 +1,9 @@
 title: Portraits I
 
+page_scans:
+    - 'https://babel.hathitrust.org/cgi/pt?id=uc1.$b408727&view=1up&seq=29'
+    - 'https://babel.hathitrust.org/cgi/pt?id=uc1.$b408727&view=1up&seq=30'
+    
 nowrap: true
 
 first_line: conversation with my friend is particularly

--- a/_data/poems/xli-poems/portraits-ii.yaml
+++ b/_data/poems/xli-poems/portraits-ii.yaml
@@ -1,5 +1,9 @@
 title: Portraits II
 
+page_scans:
+    - 'https://babel.hathitrust.org/cgi/pt?id=uc1.$b408727&view=1up&seq=31'
+    - 'https://babel.hathitrust.org/cgi/pt?id=uc1.$b408727&view=1up&seq=32'
+    
 first_line: one April dusk the
 
 text: |-1

--- a/_data/poems/xli-poems/portraits-iii.yaml
+++ b/_data/poems/xli-poems/portraits-iii.yaml
@@ -1,5 +1,8 @@
 title: Portraits III
 
+page_scans:
+    - 'https://babel.hathitrust.org/cgi/pt?id=uc1.$b408727&view=1up&seq=33'
+
 first_line: Picasso
 
 text: |-1

--- a/_data/poems/xli-poems/portraits-iv.yaml
+++ b/_data/poems/xli-poems/portraits-iv.yaml
@@ -1,5 +1,8 @@
 title: Portraits IV
 
+page_scans:
+    - 'https://babel.hathitrust.org/cgi/pt?id=uc1.$b408727&view=1up&seq=34'
+
 nowrap: true
 
 first_line: the skinny voice

--- a/_data/poems/xli-poems/portraits-ix.yaml
+++ b/_data/poems/xli-poems/portraits-ix.yaml
@@ -1,5 +1,9 @@
 title: Portraits IX
 
+page_scans:
+    - 'https://babel.hathitrust.org/cgi/pt?id=uc1.$b408727&view=1up&seq=41'
+    - 'https://babel.hathitrust.org/cgi/pt?id=uc1.$b408727&view=1up&seq=42'
+
 nowrap: true
 
 first_line: at the ferocious phenomenon of 5 o’clock i find myself gently decompos-

--- a/_data/poems/xli-poems/portraits-v.yaml
+++ b/_data/poems/xli-poems/portraits-v.yaml
@@ -1,5 +1,8 @@
 title: Portraits V
 
+page_scans:
+    - 'https://babel.hathitrust.org/cgi/pt?id=uc1.$b408727&view=1up&seq=35'
+
 nowrap: true
 
 first_line: as usual i did not find him in cafes, the more dissolute

--- a/_data/poems/xli-poems/portraits-vi.yaml
+++ b/_data/poems/xli-poems/portraits-vi.yaml
@@ -1,5 +1,9 @@
 title: Portraits VI
 
+page_scans:
+    - 'https://babel.hathitrust.org/cgi/pt?id=uc1.$b408727&view=1up&seq=36'
+    - 'https://babel.hathitrust.org/cgi/pt?id=uc1.$b408727&view=1up&seq=37'
+
 first_line: it’s just like a coffin’s
 
 text: |-1

--- a/_data/poems/xli-poems/portraits-vii.yaml
+++ b/_data/poems/xli-poems/portraits-vii.yaml
@@ -1,5 +1,8 @@
 title: Portraits VII
 
+page_scans:
+    - 'https://babel.hathitrust.org/cgi/pt?id=uc1.$b408727&view=1up&seq=38'
+
 nowrap: true
 
 first_line: my mind is

--- a/_data/poems/xli-poems/portraits-viii.yaml
+++ b/_data/poems/xli-poems/portraits-viii.yaml
@@ -1,5 +1,9 @@
 title: Portraits VIII
 
+page_scans:
+    - 'https://babel.hathitrust.org/cgi/pt?id=uc1.$b408727&view=1up&seq=39'
+    - 'https://babel.hathitrust.org/cgi/pt?id=uc1.$b408727&view=1up&seq=40'
+
 nowrap: true
 
 first_line: '5'

--- a/_data/poems/xli-poems/songs-i.yaml
+++ b/_data/poems/xli-poems/songs-i.yaml
@@ -1,5 +1,8 @@
 title: Songs I
 
+page_scans:
+    - 'https://babel.hathitrust.org/cgi/pt?id=uc1.$b408727&view=1up&seq=15'
+
 first_line: |-1
  the
      sky

--- a/_data/poems/xli-poems/songs-ii.yaml
+++ b/_data/poems/xli-poems/songs-ii.yaml
@@ -1,5 +1,8 @@
 title: Songs II
 
+page_scans:
+    - 'https://babel.hathitrust.org/cgi/pt?id=uc1.$b408727&view=1up&seq=16'
+
 first_line: of my
 
 text: |-1

--- a/_data/poems/xli-poems/songs-iii.yaml
+++ b/_data/poems/xli-poems/songs-iii.yaml
@@ -1,5 +1,8 @@
 title: Songs III
 
+page_scans:
+    - 'https://babel.hathitrust.org/cgi/pt?id=uc1.$b408727&view=1up&seq=17'
+
 first_line: when life is quite through with
 
 text: |-1

--- a/_data/poems/xli-poems/songs-iv.yaml
+++ b/_data/poems/xli-poems/songs-iv.yaml
@@ -1,5 +1,8 @@
 title: Songs IV
 
+page_scans:
+    - 'https://babel.hathitrust.org/cgi/pt?id=uc1.$b408727&view=1up&seq=18'
+
 first_line: into the smiting
 
 text: |-1

--- a/_data/poems/xli-poems/songs-ix.yaml
+++ b/_data/poems/xli-poems/songs-ix.yaml
@@ -1,5 +1,8 @@
 title: Songs IX
 
+page_scans:
+    - 'https://babel.hathitrust.org/cgi/pt?id=uc1.$b408727&view=1up&seq=23'
+
 first_line: Lady of Silence
 
 text: |-1

--- a/_data/poems/xli-poems/songs-v.yaml
+++ b/_data/poems/xli-poems/songs-v.yaml
@@ -1,5 +1,8 @@
 title: Songs V
 
+page_scans:
+    - 'https://babel.hathitrust.org/cgi/pt?id=uc1.$b408727&view=1up&seq=19'
+
 first_line: Where’s Madge then,
 
 text: |-1

--- a/_data/poems/xli-poems/songs-vi.yaml
+++ b/_data/poems/xli-poems/songs-vi.yaml
@@ -1,5 +1,8 @@
 title: Songs VI
 
+page_scans:
+    - 'https://babel.hathitrust.org/cgi/pt?id=uc1.$b408727&view=1up&seq=20'
+
 first_line: after five
 
 text: |-1

--- a/_data/poems/xli-poems/songs-vii.yaml
+++ b/_data/poems/xli-poems/songs-vii.yaml
@@ -1,5 +1,8 @@
 title: Songs VII
 
+page_scans:
+    - 'https://babel.hathitrust.org/cgi/pt?id=uc1.$b408727&view=1up&seq=21'
+
 first_line: |-1
  between green
                mountains

--- a/_data/poems/xli-poems/songs-viii.yaml
+++ b/_data/poems/xli-poems/songs-viii.yaml
@@ -1,5 +1,8 @@
 title: Songs VIII
 
+page_scans:
+    - 'https://babel.hathitrust.org/cgi/pt?id=uc1.$b408727&view=1up&seq=22'
+
 first_line: in the rain-
 
 text: |-1

--- a/_data/poems/xli-poems/songs-x.yaml
+++ b/_data/poems/xli-poems/songs-x.yaml
@@ -1,5 +1,8 @@
 title: Songs X
 
+page_scans:
+    - 'https://babel.hathitrust.org/cgi/pt?id=uc1.$b408727&view=1up&seq=24'
+
 nowrap: true
 
 first_line: the hills

--- a/_data/poems/xli-poems/songs-xi.yaml
+++ b/_data/poems/xli-poems/songs-xi.yaml
@@ -1,5 +1,8 @@
 title: Songs XI
 
+page_scans:
+    - 'https://babel.hathitrust.org/cgi/pt?id=uc1.$b408727&view=1up&seq=25'
+
 nowrap: true
 
 first_line: |-1

--- a/_data/poems/xli-poems/songs-xii.yaml
+++ b/_data/poems/xli-poems/songs-xii.yaml
@@ -1,5 +1,8 @@
 title: Songs XII
 
+page_scans:
+    - 'https://babel.hathitrust.org/cgi/pt?id=uc1.$b408727&view=1up&seq=26'
+
 first_line: cruelly,love
 
 text: |-1

--- a/_data/poems/xli-poems/sonnets-i.yaml
+++ b/_data/poems/xli-poems/sonnets-i.yaml
@@ -1,5 +1,8 @@
 title: Sonnets I
 
+page_scans:
+    - 'https://babel.hathitrust.org/cgi/pt?id=uc1.$b408727&view=1up&seq=45'
+
 first_line: if learned darkness from our searched world
 
 text: |-1

--- a/_data/poems/xli-poems/sonnets-ii.yaml
+++ b/_data/poems/xli-poems/sonnets-ii.yaml
@@ -1,5 +1,8 @@
 title: Sonnets II
 
+page_scans:
+    - 'https://babel.hathitrust.org/cgi/pt?id=uc1.$b408727&view=1up&seq=46'
+
 first_line: O Thou to whom the musical white spring
 
 text: |-1

--- a/_data/poems/xli-poems/sonnets-iii.yaml
+++ b/_data/poems/xli-poems/sonnets-iii.yaml
@@ -1,5 +1,8 @@
 title: Sonnets III
 
+page_scans:
+    - 'https://babel.hathitrust.org/cgi/pt?id=uc1.$b408727&view=1up&seq=47'
+
 nowrap: true
 
 first_line: when unto nights of autumn do complain

--- a/_data/poems/xli-poems/sonnets-iv.yaml
+++ b/_data/poems/xli-poems/sonnets-iv.yaml
@@ -1,5 +1,8 @@
 title: Sonnets IV
 
+page_scans:
+    - 'https://babel.hathitrust.org/cgi/pt?id=uc1.$b408727&view=1up&seq=48'
+
 first_line: 'this is the garden:colours come and go'
 
 text: |-1

--- a/_data/poems/xli-poems/sonnets-ix.yaml
+++ b/_data/poems/xli-poems/sonnets-ix.yaml
@@ -1,5 +1,8 @@
 title: Sonnets IX
 
+page_scans:
+    - 'https://babel.hathitrust.org/cgi/pt?id=uc1.$b408727&view=1up&seq=53'
+
 first_line: when my sensational moments are no more
 
 text: |-1

--- a/_data/poems/xli-poems/sonnets-v.yaml
+++ b/_data/poems/xli-poems/sonnets-v.yaml
@@ -1,5 +1,8 @@
 title: Sonnets V
 
+page_scans:
+    - 'https://babel.hathitrust.org/cgi/pt?id=uc1.$b408727&view=1up&seq=49'
+
 first_line: Thou in whose swordgreat story shine the deeds
 
 text: |-1

--- a/_data/poems/xli-poems/sonnets-vi.yaml
+++ b/_data/poems/xli-poems/sonnets-vi.yaml
@@ -1,5 +1,8 @@
 title: Sonnets VI
 
+page_scans:
+    - 'https://babel.hathitrust.org/cgi/pt?id=uc1.$b408727&view=1up&seq=50'
+
 first_line: when the proficient poison sure sleep
 
 text: |-1
@@ -23,4 +26,3 @@ text: |-1
          and when thy bashful hands assume
 
  silence beyond the mystery of rhyme
-

--- a/_data/poems/xli-poems/sonnets-vii.yaml
+++ b/_data/poems/xli-poems/sonnets-vii.yaml
@@ -1,5 +1,8 @@
 title: Sonnets VII
 
+page_scans:
+    - 'https://babel.hathitrust.org/cgi/pt?id=uc1.$b408727&view=1up&seq=51'
+
 first_line: and what were roses.     Perfume? for i do
 
 text: |-1

--- a/_data/poems/xli-poems/sonnets-viii.yaml
+++ b/_data/poems/xli-poems/sonnets-viii.yaml
@@ -1,5 +1,8 @@
 title: Sonnets VIII
 
+page_scans:
+    - 'https://babel.hathitrust.org/cgi/pt?id=uc1.$b408727&view=1up&seq=52'
+
 first_line: come nothing to my comparable soul
 
 text: |-1

--- a/_data/poems/xli-poems/sonnets-x.yaml
+++ b/_data/poems/xli-poems/sonnets-x.yaml
@@ -1,5 +1,8 @@
 title: Sonnets X
 
+page_scans:
+    - 'https://babel.hathitrust.org/cgi/pt?id=uc1.$b408727&view=1up&seq=54'
+
 first_line: I have seen her stealthily frail
 
 text: |-1

--- a/_data/poems/xli-poems/sonnets-xi.yaml
+++ b/_data/poems/xli-poems/sonnets-xi.yaml
@@ -1,5 +1,8 @@
 title: Sonnets XI
 
+page_scans:
+    - 'https://babel.hathitrust.org/cgi/pt?id=uc1.$b408727&view=1up&seq=55'
+
 first_line: |-1
  who’s most afraid of death?thou
                                  art of him

--- a/_data/poems/xli-poems/sonnets-xii.yaml
+++ b/_data/poems/xli-poems/sonnets-xii.yaml
@@ -1,5 +1,8 @@
 title: Sonnets XII
 
+page_scans:
+    - 'https://babel.hathitrust.org/cgi/pt?id=uc1.$b408727&view=1up&seq=56'
+
 first_line: perhaps it is to feel strike
 
 text: |-1

--- a/_data/poems/xli-poems/sonnets-xiii.yaml
+++ b/_data/poems/xli-poems/sonnets-xiii.yaml
@@ -1,5 +1,8 @@
 title: Sonnets XIII
 
+page_scans:
+    - 'https://babel.hathitrust.org/cgi/pt?id=uc1.$b408727&view=1up&seq=57'
+
 first_line: when i am in Boston,i do not speak
 
 text: |-1

--- a/_data/poems/xli-poems/sonnets-xiv.yaml
+++ b/_data/poems/xli-poems/sonnets-xiv.yaml
@@ -1,5 +1,8 @@
 title: Sonnets XIV
 
+page_scans:
+    - 'https://babel.hathitrust.org/cgi/pt?id=uc1.$b408727&view=1up&seq=58'
+
 first_line: will suddenly trees leap from winter and will
 
 text: |-1

--- a/_data/poems/xli-poems/sonnets-xv.yaml
+++ b/_data/poems/xli-poems/sonnets-xv.yaml
@@ -1,5 +1,8 @@
 title: Sonnets XV
 
+page_scans:
+    - 'https://babel.hathitrust.org/cgi/pt?id=uc1.$b408727&view=1up&seq=59'
+
 first_line: a fragrant sag of fruit distinctly grouped.
 
 text: |-1

--- a/_data/poems/xli-poems/sonnets-xvi.yaml
+++ b/_data/poems/xli-poems/sonnets-xvi.yaml
@@ -1,5 +1,8 @@
 title: Sonnets XVI
 
+page_scans:
+    - 'https://babel.hathitrust.org/cgi/pt?id=uc1.$b408727&view=1up&seq=60'
+
 nowrap: true
 
 first_line: by god i want above fourteenth


### PR DESCRIPTION
See #31 for discussion. 

For now, the YAML for each poem in XLI poems has a `page_scans` property, which is an array of one or more URL strings.

If we decide we want to add page numbers for the edition, they can be computed by subtracting 6 from the value of `seq` in the URL, eg

https://babel.hathitrust.org/cgi/pt?id=uc1.$b408727&view=1up&seq=32

is page 26
